### PR TITLE
cosmetic: _id holds the OID assigned to an object in mongo

### DIFF
--- a/Chapters/Voyage/Voyage.pillar
+++ b/Chapters/Voyage/Voyage.pillar
@@ -200,12 +200,12 @@ After we add ==isVoyageRoot== to ==Point class==, and save the rectangle, in the
 	"origin" : {
 		"#collection" : "point",
 		"#instanceOf" : "Point",
-		"__id" : ObjectId("7804c56c0000000000000000")
+		"_id" : ObjectId("7804c56c0000000000000000")
 	},
 	"corner" : {
 		"#collection" : "point",
 		"#instanceOf" : "Point",
-		"__id" : ObjectId("2a731f310000000000000000")
+		"_id" : ObjectId("2a731f310000000000000000")
 	}
 }
 ]]]
@@ -398,7 +398,7 @@ possibly may no longer be able to query these objects by their OID (by
 using ==voyageId==), since mongo expects a certain format. If you do, you should check your format by querying for it in the mongo console, for example as below. If you get the ==result Error: invalid object id: length==, then you will not be able to query this object by id.
 
 [[[
-> db.Trips.find({"person.__id" : ObjectId("190372")})
+> db.Trips.find({"person._id" : ObjectId("190372")})
 Fri Aug 28 14:21:10.815 Error: invalid object id: length
 ]]]
 
@@ -457,7 +457,7 @@ With No-SQL databases, it is impossible to query on multiple collections (the eq
 returned by a previous query and using that id to match another object. An example where we match colors ==color== to a reference color ==refCol== is as follows:
 
 [[[
-[ :each | (each at: 'color.__id') = refCol voyageId ]
+[ :each | (each at: 'color._id') = refCol voyageId ]
 ]]]
 
 !!!Using the at: message to access embedded documents

--- a/Chapters/VoyageExtras/VoyageExtras.pillar
+++ b/Chapters/VoyageExtras/VoyageExtras.pillar
@@ -22,7 +22,7 @@ Or you have an instance (in this example of ==Person==) which is in a root colle
  Trip
 		selectMany:
 			{('receipts.description' -> aString).
-			('person.__id' -> aPerson voyageId)} asDictionary
+			('person._id' -> aPerson voyageId)} asDictionary
 
 ]]]
 
@@ -173,19 +173,19 @@ Trip
 "#version" : 876079653, 
 "person" : { 
 	"#collection" : "Persons", 
-	"__id" : ObjectId("55cf2bbb3c9b0fe702000007") }, 
+	"_id" : ObjectId("55cf2bbb3c9b0fe702000007") }, 
 "receipts" : [ 	
 	{ "currency" : "EUR", 	
 	"date" : { "#instanceOf" : "ZTimestamp", "jdn" : 2457249, "secs" : 0 }, 	
 	"exchangeRate" : 1, 	
 	"paymentMethod" : {
 		"#collection" : "PaymentMethods", 	
-		"__id" : ObjectId("55cf2bbb3c9b0fe702000003") }, 
+		"_id" : ObjectId("55cf2bbb3c9b0fe702000003") }, 
 	"receiptDescription" : "Taxi zum Hotel", 	
 	"receiptNumber" : 1, 	
 	"trip" : { 
 		"#collection" : "Trips", 	
-		"__id" : ObjectId("55cf2bc73c9b0fe702000008") } } ], 
+		"_id" : ObjectId("55cf2bc73c9b0fe702000008") } } ], 
 	"startPlace" : "Österreich",    
 	"tripName" : "asdf", 
 	"tripNumber" : 1 }
@@ -199,7 +199,7 @@ The corresponding ==person== points to all its ==trips== and to its ==company==.
 "bankName" : "",
  "company" : { 
 "#collection" : "Companies", 
-"__id" : ObjectId("55cf2bbb3c9b0fe702000002") },
+"_id" : ObjectId("55cf2bbb3c9b0fe702000002") },
 "email" : "bb@spesenfuchs.de", 
 "firstName" : "Berta",
 "lastName" : "Block",  
@@ -209,7 +209,7 @@ The corresponding ==person== points to all its ==trips== and to its ==company==.
 "trips" : [ 	
 {
 "#collection" : "Trips", 	
-"__id" : ObjectId("55cf2bc73c9b0fe702000008") } ] }
+"_id" : ObjectId("55cf2bc73c9b0fe702000008") } ] }
 ]]]
 
 If your domain has strictly delimited areas, e.g. clients, you could think about creating one repository per area (client). 

--- a/Chapters/VoyageTutorial/VoyageTutorial.pillar
+++ b/Chapters/VoyageTutorial/VoyageTutorial.pillar
@@ -341,12 +341,12 @@ are not nested inside the hero documents.
 		{
 			"#collection" : "Power",
 			"#instanceOf" : "Power",
-			"__id" : ObjectId("d84745dd421aa909b4000005")
+			"_id" : ObjectId("d84745dd421aa909b4000005")
 		},
 		{
 			"#collection" : "Power",
 			"#instanceOf" : "Power",
-			"__id" : ObjectId("d84745dd421aa909b4000006")
+			"_id" : ObjectId("d84745dd421aa909b4000006")
 		}
 	]
 }

--- a/Material/VoyageTutorial/VoyageTutorial.pillar
+++ b/Material/VoyageTutorial/VoyageTutorial.pillar
@@ -368,12 +368,12 @@ are not nested inside the hero documents.
 		{
 			"#collection" : "Power",
 			"#instanceOf" : "Power",
-			"__id" : ObjectId("d84745dd421aa909b4000005")
+			"_id" : ObjectId("d84745dd421aa909b4000005")
 		},
 		{
 			"#collection" : "Power",
 			"#instanceOf" : "Power",
-			"__id" : ObjectId("d84745dd421aa909b4000006")
+			"_id" : ObjectId("d84745dd421aa909b4000006")
 		}
 	]
 }


### PR DESCRIPTION
Mongo is using/assigning the _id attribute and not __id. Use GNU
sed to replace all occurences with a single underscore. It seems
all of them referred to the Mongo _id.