### PR TITLE
misc: Link to the PDFs of this manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,16 @@
 
 [![Build status][badge]][travis]
 
+[Voyage] is a small persistence framework developed by Esteban
+Lorenzano, constructed as a small layer between the objects and
+a persistency mechanism often a document noSql database and this
+is a booklet describing its usage and operation.
+
+[Browse] the directory for released versions of the booklet or
+look here for more [Books and Booklets](http://files.pharo.org/books/)
+
+
 [travis]: https://travis-ci.org/SquareBracketAssociates/Booklet-Voyage
 [badge]: https://travis-ci.org/SquareBracketAssociates/Booklet-Voyage.svg?branch=master
+[Voyage]: https://github.com/pharo-nosql/voyage
+[Browse]: http://files.pharo.org/books-pdfs/booklet-Voyage/


### PR DESCRIPTION
Somebody ending in this repository might not know what Voyage
is. Take the description from the  manual, link to the directory
that will hold the PDFs and point to other books and booklets too.

Feel free to proposed improved wording of the introduction and
link to the PDFs. Instead of pointing to a directory I would have
preferred to point to the latest PDF but there doesn't seem to be
such a link. Better point to the directory instead of having a
dead link in the future.